### PR TITLE
Fixing reading of sequence to big endian.

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Message.java
+++ b/core/src/main/java/org/bitcoinj/core/Message.java
@@ -286,10 +286,20 @@ public abstract class Message {
             checkState(false, "Length field has not been set in %s.", getClass().getSimpleName());
         return length;
     }
-
+    
     long readUint32() throws ProtocolException {
         try {
             long u = Utils.readUint32(payload, cursor);
+            cursor += 4;
+            return u;
+        } catch (ArrayIndexOutOfBoundsException e) {
+            throw new ProtocolException(e);
+        }
+    }
+    
+    long readUint32BE() throws ProtocolException {
+        try {
+            long u = Utils.readUint32BE(payload, cursor);
             cursor += 4;
             return u;
         } catch (ArrayIndexOutOfBoundsException e) {

--- a/core/src/main/java/org/bitcoinj/core/TransactionInput.java
+++ b/core/src/main/java/org/bitcoinj/core/TransactionInput.java
@@ -136,7 +136,7 @@ public class TransactionInput extends ChildMessage {
         int scriptLen = (int) readVarInt();
         length = cursor - offset + scriptLen + 4;
         scriptBytes = readBytes(scriptLen);
-        sequence = readUint32();
+        sequence = readUint32BE();
     }
 
     @Override


### PR DESCRIPTION
Sequence was incorrectly read as little endian, but is big endian. Should fix issue where `nLockTime` transactions get falsely labeled as OptInRBF transactions.
